### PR TITLE
Add train-model and evaluate-model jobs to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
     - name: Ensure all dependencies are installed
       run: uv pip install .
 
+    - name: List installed packages
+      run: uv pip list
+
     - name: Download & preprocess the data
       run: python src/load_data.py
 
@@ -84,6 +87,9 @@ jobs:
 
     - name: Ensure all dependencies are installed
       run: uv pip install .
+
+    - name: List installed packages
+      run: uv pip list
 
     - name: Download iris-model artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Install dependencies
       run: make install
 
+    - name: Ensure all dependencies are installed
+      run: uv pip install .
+
     - name: Download & preprocess the data
       run: python src/load_data.py
 
@@ -78,6 +81,9 @@ jobs:
 
     - name: Install dependencies
       run: make install
+
+    - name: Ensure all dependencies are installed
+      run: uv pip install .
 
     - name: Download iris-model artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,67 @@ jobs:
 
     - name: Run tests with coverage
       run: make test-cov
+
+  train-model:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Download & preprocess the data
+      run: python src/load_data.py
+
+    - name: Run the training script
+      run: python src/train.py
+
+    - name: Upload model artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: iris-model
+        path: models/model.joblib
+
+  evaluate-model:
+    runs-on: ubuntu-latest
+    needs: train-model
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+
+    - name: Set up Python
+      run: uv python install 3.11
+
+    - name: Install dependencies
+      run: make install
+
+    - name: Download iris-model artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: iris-model
+        path: models/
+
+    - name: Verify model file exists
+      run: ls -la models/model.joblib
+
+    - name: Run evaluation script
+      run: python src/evaluate.py
+
+    - name: Upload evaluation metrics
+      uses: actions/upload-artifact@v4
+      with:
+        name: evaluation-metrics
+        path: data/eval.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
     - name: Download & preprocess the data
       run: python src/load_data.py
 
+    - name: Split the dataset
+      run: python src/split_dataset.py --test_size 0.2
+
     - name: Run the training script
       run: python src/train.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,10 @@ jobs:
       run: make install
 
     - name: Ensure all dependencies are installed
-      run: uv pip install .
+      run: pip install .
 
     - name: List installed packages
-      run: uv pip list
+      run: pip list
 
     - name: Download & preprocess the data
       run: python src/load_data.py
@@ -86,10 +86,10 @@ jobs:
       run: make install
 
     - name: Ensure all dependencies are installed
-      run: uv pip install .
+      run: pip install .
 
     - name: List installed packages
-      run: uv pip list
+      run: pip list
 
     - name: Download iris-model artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,12 @@ jobs:
         name: iris-model
         path: models/
 
+    - name: Download & preprocess the data
+      run: python src/load_data.py
+
+    - name: Split the dataset
+      run: python src/split_dataset.py --test_size 0.2
+
     - name: Verify model file exists
       run: ls -la models/model.joblib
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,7 @@ ignore_missing_imports = true
 testpaths = ["tests"]          # # Directory where your tests are located
 pythonpath = ["."]             # This adds the project root to Python path
 addopts = "--cov=src --cov-report=term-missing --cov-report=html"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR adds two new jobs to the CI workflow: train-model and evaluate-model jobs with proper dependencies and artifact handling.